### PR TITLE
Replace deprecated File.exists? with File.exist?

### DIFF
--- a/app/controllers/active_hashcash/assets_controller.rb
+++ b/app/controllers/active_hashcash/assets_controller.rb
@@ -7,7 +7,7 @@ module ActiveHashcash
     def show
       if endpoints.include?(file_name = File.basename(request.path))
         file_path = ActiveHashcash::Engine.root.join / "app/views/active_hashcash/assets" / file_name
-        if File.exists?("#{file_path}.erb")
+        if File.exist?("#{file_path}.erb")
           render(params[:id], mime_type: mime_type)
         else
           render(file: file_path)


### PR DESCRIPTION
`File.exists?` was deprecated in Ruby 2.1.0 and has been removed in the Ruby 3.2.0.

https://bugs.ruby-lang.org/issues/17391
