### PR TITLE
Add throttle rules to slow down pushy IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `ActiveHashcash.penality_rules` to slow down pushy IPs
 - Replace SHA-1 with SHA-256 for proof-of-work stamps
 - Mine stamps in a Web Worker using pure JS SHA-256 (keeps the main thread unblocked)
 - Support SHA-1 fallback on the backend for backward compatibility (via the `ext` stamp field)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add `ActiveHashcash.penality_rules` to slow down pushy IPs
+- Add `ActiveHashcash.throttle_rules` to slow down pushy IPs
 
 ## 0.5.0 (2026-08-08)
 

--- a/README.md
+++ b/README.md
@@ -170,14 +170,49 @@ rails db:migrate
 
 ## Complexity
 
-Complexity is the most important parameter. By default its value is 20 and requires most of the time 5 to 20 seconds to be solved on a decent laptop.
-The user won't wait that long, since he needs to fill the form while the problem is solving.
-However, if your application includes people with slow and old devices, then consider lowering this value, to 16 or 18.
+Complexity controls the base proof-of-work difficulty.
+Increasing by one double the work time.
+By default its value is 20 and you can change it with `ActiveHashcash.bits = 24` or by overriding the method `hashcash_bits` in the controller.
 
-You can change the minimum complexity with `ActiveHashcash.bits = 20`.
+### Penalities
 
-Since version 0.3.0, the complexity increases with the number of stamps spent during le last 24H from the same IP address.
-Thus it becomes very efficient to slow down brute force attacks.
+A penality is added for pushy IPs which submit valid stamps too fast.
+The goal is to slow down attackers using a botnet.
+The penality rules can be defined like this.
+
+```ruby
+ActiveHashcash.penalty_rules = [
+  {period: 1.hour, rate: 0.5},
+  {period: 24.hours, rate: 0.25}
+]
+```
+
+For every valid stamps sent less than an hour ago, a penality of 0.5 is added.
+Then, for every valid stamp sent between 1 and 24 hours ago a penality of 0.25 is added.
+Thus, if an IP sent 1 stamp one minue ago, and 3 others few hours ago, it add a complexity of `(1 * 0.5 + 3 * 0.25).floor # => 1`.
+So next hashcash must have a complexity of `ActiveHashcash.bits + 1`.
+
+If you have many users behind the same IP, such as a NAT, you can either lower the rates or disable the penality.
+In your controller, override the method `hashcash_bits_penality`:
+
+```ruby
+class ApplicationController
+  def hashcash_bits_penality
+    # Only the base complexity (ActiveHashcash.bits) will apply for people with IP 1.2.3.4
+    hashcash_ip_address == "1.2.3.4" ? 0 : super
+  end
+end
+```
+
+Or, if someone is attacking you from a specific country:
+
+```ruby
+class ApplicationController
+  def hashcash_bits_penality
+    geoip.country(hashcash_ip_address).country_code == "XX" ? super + 2 : super
+  end
+end
+```
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,23 @@ class ApplicationController
 end
 ```
 
+## Testing Your Application
+
+To keep your test suite fast set `ActiveHashcash.bits = 1` in `test_helper.rb`.
+
+Use `ActiveHashcash::Stamp.mint` to submit hashcash to your sensitive forms:
+
+```ruby
+class SessionControllerTest < ActionDispatch::IntegrationTest
+  def test_create
+    # ...
+    hashcash = ActiveHashcash::Stamp.mint(host).to_s
+    post(session_path, params: {email: email, password: password, hashcash: hashcash})
+    # ...
+  end
+end
+```
+
 ## Limitations
 
 The JavaScript implementation is slower than the official C version.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ end
 
 ## Testing
 
-Browser tests submit the real form, so they have to compute a real stamp. At the default 16 bits this adds noticeable time to every submission and slows down your suite. Drop the complexity in the test environment so it finishes almost instantly:
+Browser tests submit the real form, so they have to compute a real stamp. At the default complexity this adds noticeable time to every submission and slows down your suite. Drop the complexity in the test environment so it finishes almost instantly:
 
 ```ruby
 # spec/rails_helper.rb (RSpec) or test/test_helper.rb (Minitest)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,12 @@ end
 
 ## Testing Your Application
 
-To keep your test suite fast set `ActiveHashcash.bits = 1` in `test_helper.rb`.
+Browser tests submit the real form, so they have to compute a real stamp. At the default complexity this adds noticeable time to every submission and slows down your suite. Drop the complexity in the test environment so it finishes almost instantly:
+
+```ruby
+# spec/rails_helper.rb (RSpec) or test/test_helper.rb (Minitest)
+ActiveHashcash.bits = 1
+```
 
 Use `ActiveHashcash::Stamp.mint` to submit hashcash to your sensitive forms:
 
@@ -233,21 +238,6 @@ class SessionControllerTest < ActionDispatch::IntegrationTest
     # ...
   end
 end
-```
-
-## Testing
-
-Browser tests submit the real form, so they have to compute a real stamp. At the default complexity this adds noticeable time to every submission and slows down your suite. Drop the complexity in the test environment so it finishes almost instantly:
-
-```ruby
-# spec/rails_helper.rb (RSpec) or test/test_helper.rb (Minitest)
-ActiveHashcash.bits = 2
-```
-
-In controller tests, provide the hashcash this way:
-
-```ruby
-post(url, params: {hashcash: ActiveHashcash::Stamp.mint(host).to_s})
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@ Thus, if an IP sent 1 stamp one minue ago, and 3 others few hours ago, it add a 
 So next hashcash must have a complexity of `ActiveHashcash.bits + 1`.
 
 If you have many users behind the same IP, such as a NAT, you can either lower the rates or disable the penality.
-In your controller, override the method `hashcash_bits_penality`:
+In your controller, override the method `hashcash_throttle_penality`:
 
 ```ruby
 class ApplicationController
-  def hashcash_bits_penality
+  def hashcash_throttle_penality
     # Only the base complexity (ActiveHashcash.bits) will apply for people with IP 1.2.3.4
     hashcash_ip_address == "1.2.3.4" ? 0 : super
   end
@@ -208,7 +208,7 @@ Or, if someone is attacking you from a specific country:
 
 ```ruby
 class ApplicationController
-  def hashcash_bits_penality
+  def hashcash_throttle_penality
     geoip.country(hashcash_ip_address).country_code == "XX" ? super + 2 : super
   end
 end

--- a/README.md
+++ b/README.md
@@ -153,21 +153,6 @@ authenticate :user, -> (u) { u.admin? } do # Supposing there is a User#admin? me
 end
 ```
 
-### Before version 0.3.0
-
-You must have Redis in order to prevent double spent stamps. Otherwise it will be useless.
-It automatically tries to connect with the environment variables `ACTIVE_HASHCASH_REDIS_URL` or `REDIS_URL`.
-You can also manually set the URL with `ActiveHashcash.redis_url = redis://user:password@localhost:6379`.
-
-You should call `ActiveHashcash::Store#clean` once a day, to remove expired stamps.
-
-To upgrade from 0.2.0 you must run the migration :
-
-```
-rails active_hashcash:install:migrations
-rails db:migrate
-```
-
 ## Complexity
 
 Complexity controls the base proof-of-work difficulty.
@@ -247,6 +232,21 @@ It uses a pure JS SHA-256 implementation running inside a Web Worker, which keep
 A synchronous tight loop avoids the per-call async overhead of `crypto.subtle.digest()`, making it the fastest browser-side approach across Chrome and Safari.
 
 No `crypto.subtle` or secure context (HTTPS) is required, so it works in any environment including plain HTTP during development.
+
+### Before version 0.3.0
+
+You must have Redis in order to prevent double spent stamps. Otherwise it will be useless.
+It automatically tries to connect with the environment variables `ACTIVE_HASHCASH_REDIS_URL` or `REDIS_URL`.
+You can also manually set the URL with `ActiveHashcash.redis_url = redis://user:password@localhost:6379`.
+
+You should call `ActiveHashcash::Store#clean` once a day, to remove expired stamps.
+
+To upgrade from 0.2.0 you must run the migration :
+
+```
+rails active_hashcash:install:migrations
+rails db:migrate
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -171,14 +171,14 @@ rails db:migrate
 ## Complexity
 
 Complexity controls the base proof-of-work difficulty.
-Increasing by one double the work time.
+Increasing by one doubles the work time.
 By default its value is 20 and you can change it with `ActiveHashcash.bits = 24` or by overriding the method `hashcash_bits` in the controller.
 
-### Penalities
+### Penalties
 
-A penality is added for pushy IPs which submit valid stamps too fast.
+A penalty is added for pushy IPs which submit valid stamps too fast.
 The goal is to slow down attackers using a botnet.
-The penality rules can be defined like this.
+The penalty rules can be defined like this.
 
 ```ruby
 ActiveHashcash.throttle_rules = [
@@ -187,19 +187,19 @@ ActiveHashcash.throttle_rules = [
 ]
 ```
 
-For every valid stamps sent less than an hour ago, a penality of 0.5 is added.
-Then, for every valid stamp sent between 1 and 24 hours ago a penality of 0.25 is added.
-Thus, if an IP sent 1 stamp one minue ago, and 3 others few hours ago, it add a complexity of `(1 * 0.5 + 3 * 0.25).floor # => 1`.
+For every valid stamp sent less than an hour ago, a penalty of 0.5 is added.
+Then, for every valid stamp sent between 1 and 24 hours ago a penalty of 0.25 is added.
+Thus, if an IP sent 1 stamp one minute ago, and 3 others few hours ago, it adds a complexity of `(1 * 0.5 + 3 * 0.25).floor # => 1`.
 So next hashcash must have a complexity of `ActiveHashcash.bits + 1`.
 
-If you have many users behind the same IP, such as a NAT, you can either lower the rates or disable the penality.
-In your controller, override the method `hashcash_throttle_penality`:
+If you have many users behind the same IP, such as a NAT, you can either lower the rates or disable the penalty.
+In your controller, override the method `hashcash_throttle_penalty`:
 
 ```ruby
 class SessionController < ApplicationController
   include ActiveHashcash
 
-  def hashcash_throttle_penality
+  def hashcash_throttle_penalty
     # Only the base complexity (ActiveHashcash.bits) will apply for people with IP 1.2.3.4
     hashcash_ip_address == "1.2.3.4" ? 0 : super
   end
@@ -212,7 +212,7 @@ Or, if someone is attacking you from a specific country:
 class SessionController < ApplicationController
   include ActiveHashcash
 
-  def hashcash_throttle_penality
+  def hashcash_throttle_penalty
     geoip.country(hashcash_ip_address).country_code == "XX" ? super + 2 : super
   end
 end

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The goal is to slow down attackers using a botnet.
 The penality rules can be defined like this.
 
 ```ruby
-ActiveHashcash.penalty_rules = [
+ActiveHashcash.throttle_rules = [
   {period: 1.hour, rate: 0.5},
   {period: 24.hours, rate: 0.25}
 ]

--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ If you have many users behind the same IP, such as a NAT, you can either lower t
 In your controller, override the method `hashcash_throttle_penality`:
 
 ```ruby
-class ApplicationController
+class SessionController < ApplicationController
+  include ActiveHashcash
+
   def hashcash_throttle_penality
     # Only the base complexity (ActiveHashcash.bits) will apply for people with IP 1.2.3.4
     hashcash_ip_address == "1.2.3.4" ? 0 : super
@@ -207,7 +209,9 @@ end
 Or, if someone is attacking you from a specific country:
 
 ```ruby
-class ApplicationController
+class SessionController < ApplicationController
+  include ActiveHashcash
+
   def hashcash_throttle_penality
     geoip.country(hashcash_ip_address).country_code == "XX" ? super + 2 : super
   end

--- a/app/models/active_hashcash/stamp.rb
+++ b/app/models/active_hashcash/stamp.rb
@@ -26,6 +26,22 @@ module ActiveHashcash
       scope
     end
 
+    def self.sum_by_periods(periods)
+      return [] if periods.blank?
+
+      cutoffs = periods.map(&:ago)
+      columns = cutoffs.each_with_index.map do |cutoff, index|
+        if index.zero?
+          sanitize_sql(["sum(CASE WHEN created_at >= ? THEN 1 ELSE 0 END)", cutoff])
+        else
+          previous_cutoff = cutoffs[index - 1]
+          sanitize_sql(["sum(CASE WHEN created_at < ? AND created_at >= ? THEN 1 ELSE 0 END)", previous_cutoff, cutoff])
+        end
+      end.join(", ")
+
+      pluck(Arel.sql(columns)).first
+    end
+
     # Verify and save the hashcash stamp.
     # Saving in the database prevent from double spending the same stamp.
     def self.spend(string, resource, bits, date, options = {})

--- a/app/models/active_hashcash/stamp.rb
+++ b/app/models/active_hashcash/stamp.rb
@@ -26,6 +26,8 @@ module ActiveHashcash
       scope
     end
 
+    # Returns stamp counts per period for disjoint windows.
+    # +periods+ must be sorted shortest to longest (as ensured by ActiveHashcash.throttle_rules=).
     def self.sum_by_periods(periods)
       return [] if periods.blank?
 
@@ -38,8 +40,7 @@ module ActiveHashcash
           sanitize_sql(["sum(CASE WHEN created_at < ? AND created_at >= ? THEN 1 ELSE 0 END)", previous_cutoff, cutoff])
         end
       end.join(", ")
-
-      pluck(Arel.sql(columns)).first
+      Array.wrap(pluck(Arel.sql(columns)).first)
     end
 
     # Verify and save the hashcash stamp.

--- a/app/models/active_hashcash/stamp.rb
+++ b/app/models/active_hashcash/stamp.rb
@@ -40,7 +40,8 @@ module ActiveHashcash
           sanitize_sql(["sum(CASE WHEN created_at < ? AND created_at >= ? THEN 1 ELSE 0 END)", previous_cutoff, cutoff])
         end
       end.join(", ")
-      Array.wrap(pluck(Arel.sql(columns)).first)
+
+      Array.wrap(where(created_at: cutoffs.min..).pluck(Arel.sql(columns)).first)
     end
 
     # Verify and save the hashcash stamp.

--- a/lib/active_hashcash.rb
+++ b/lib/active_hashcash.rb
@@ -26,10 +26,33 @@ module ActiveHashcash
 
   # This is base complexity.
   # Consider lowering it to not exclude people with old and slow devices.
-  mattr_accessor :bits, instance_accessor: false, default: 16
+  mattr_accessor :bits, instance_accessor: false, default: 20
+
+  # Flexible complexity penalty rules applied to pushy IP addresses.
+  # Each rule must be a hash with:
+  # - :period => time window considered (e.g. 5.minutes, 1.hour, 1.day)
+  # - :rate => multiplier applied to the number of stamps in that window
+  # Rules are applied from shortest to longest period.
+  #
+  # Example:
+  #   ActiveHashcash.penalty_rules = [
+  #     {period: 5.minutes, rate: 0.5},
+  #     {period: 1.hour, rate: 0.34},
+  #     {period: 1.day, rate: 0.25}
+  #   ]
+  mattr_accessor :penalty_rules, instance_accessor: false, default: [
+    {period: 1.hour, rate: 0.5},
+    {period: 24.hours, rate: 0.25}
+  ]
 
   mattr_accessor :date_format, instance_accessor: false, default: "%y%m%d"
 
+  # Base controller class used by ActiveHashcash helpers/integration.
+  # Override this if your application subclasses the default Rails
+  # `ActionController::Base` (e.g. to apply common behavior across controllers).
+
+  # By default ActiveHashcash extends `ActionController::Base`, but you can change it to any controller,
+  # such as `AdminController` to handle authentication for the dashboard.
   mattr_accessor :base_controller_class, default: "ActionController::Base"
 
   # Call that method via a before_action when the form is submitted:
@@ -77,14 +100,18 @@ module ActiveHashcash
   end
 
   # Returns the complexity, the higher the slower it is.
-  # Complexity is increased logarithmicly for each IP during the last 24H to slowdown brute force attacks.
-  # The minimun value returned is ActiveHashcash.bits.
+  # Evantully adds a penality for pushy IPs, see hashcash_bits_penality.
   def hashcash_bits
-    if (previous_stamp_count = ActiveHashcash::Stamp.where(ip_address: hashcash_ip_address).where(created_at: 1.day.ago..).count) > 0
-      (ActiveHashcash.bits + Math.log2(previous_stamp_count)).floor
-    else
-      ActiveHashcash.bits
-    end
+    (ActiveHashcash.bits + hashcash_bits_penality).floor
+  end
+
+  # Compute a penality for pushy IPs.
+  # The penality rules can be define with `ActiveHashcash.penality_rules`.
+  def hashcash_bits_penality
+    rules = ActiveHashcash.penalty_rules || []
+    periods = rules.map { |rule| rule[:period] }
+    counts = ActiveHashcash::Stamp.where(ip_address: hashcash_ip_address).sum_by_periods(periods)
+    rules.each_with_index.sum { |rule, index| counts[index].to_i * rule[:rate].to_f }
   end
 
   # Override if you want to rename the hashcash param.

--- a/lib/active_hashcash.rb
+++ b/lib/active_hashcash.rb
@@ -49,6 +49,7 @@ module ActiveHashcash
 
   def self.throttle_rules=(rules)
     rules&.each do |rule|
+      raise ArgumentError, "ActiveHashcash.throttle_rules period must be present" if rule[:period].nil?
       raise ArgumentError, "ActiveHashcash.throttle_rules rate must be >= 0" if rule[:rate].to_f.negative?
     end
     @@throttle_rules = rules && rules.sort_by { |rule| rule[:period] }

--- a/lib/active_hashcash.rb
+++ b/lib/active_hashcash.rb
@@ -34,7 +34,7 @@ module ActiveHashcash
   # Each rule must be a hash with:
   # - :period => time window considered (e.g. 5.minutes, 1.hour, 1.day)
   # - :rate => multiplier applied to the number of stamps in that window
-  # Rules are applied from shortest to longest period.
+  # Assignment sorts rules from shortest to longest period.
   #
   # Example:
   #   ActiveHashcash.throttle_rules = [
@@ -42,10 +42,14 @@ module ActiveHashcash
   #     {period: 1.hour, rate: 0.34},
   #     {period: 1.day, rate: 0.25}
   #   ]
-  mattr_accessor :throttle_rules, instance_accessor: false, default: [
+  mattr_reader :throttle_rules, instance_accessor: false, default: [
     {period: 1.hour, rate: 0.5},
     {period: 24.hours, rate: 0.25}
   ]
+
+  def self.throttle_rules=(rules)
+    @@throttle_rules = rules && rules.sort_by { |rule| rule[:period] }
+  end
 
   mattr_accessor :date_format, instance_accessor: false, default: "%y%m%d"
 

--- a/lib/active_hashcash.rb
+++ b/lib/active_hashcash.rb
@@ -102,14 +102,14 @@ module ActiveHashcash
   end
 
   # Returns the complexity, the higher the slower it is.
-  # Evantully adds a penality for pushy IPs, see hashcash_bits_penality.
+  # Evantully adds a penality for pushy IPs, see hashcash_throttle_penality.
   def hashcash_bits
-    (ActiveHashcash.bits + hashcash_bits_penality).floor
+    (ActiveHashcash.bits + hashcash_throttle_penality).floor
   end
 
   # Compute a penality for pushy IPs.
   # The penality rules can be define with `ActiveHashcash.penality_rules`.
-  def hashcash_bits_penality
+  def hashcash_throttle_penality
     rules = ActiveHashcash.penalty_rules || []
     periods = rules.map { |rule| rule[:period] }
     counts = ActiveHashcash::Stamp.where(ip_address: hashcash_ip_address).sum_by_periods(periods)

--- a/lib/active_hashcash.rb
+++ b/lib/active_hashcash.rb
@@ -37,12 +37,12 @@ module ActiveHashcash
   # Rules are applied from shortest to longest period.
   #
   # Example:
-  #   ActiveHashcash.penalty_rules = [
+  #   ActiveHashcash.throttle_rules = [
   #     {period: 5.minutes, rate: 0.5},
   #     {period: 1.hour, rate: 0.34},
   #     {period: 1.day, rate: 0.25}
   #   ]
-  mattr_accessor :penalty_rules, instance_accessor: false, default: [
+  mattr_accessor :throttle_rules, instance_accessor: false, default: [
     {period: 1.hour, rate: 0.5},
     {period: 24.hours, rate: 0.25}
   ]
@@ -108,9 +108,9 @@ module ActiveHashcash
   end
 
   # Compute a penality for pushy IPs.
-  # The penality rules can be define with `ActiveHashcash.penality_rules`.
+  # The penality rules can be define with `ActiveHashcash.throttle_rules`.
   def hashcash_throttle_penality
-    rules = ActiveHashcash.penalty_rules || []
+    rules = ActiveHashcash.throttle_rules || []
     periods = rules.map { |rule| rule[:period] }
     counts = ActiveHashcash::Stamp.where(ip_address: hashcash_ip_address).sum_by_periods(periods)
     rules.each_with_index.sum { |rule, index| counts[index].to_i * rule[:rate].to_f }

--- a/lib/active_hashcash.rb
+++ b/lib/active_hashcash.rb
@@ -48,6 +48,9 @@ module ActiveHashcash
   ]
 
   def self.throttle_rules=(rules)
+    rules&.each do |rule|
+      raise ArgumentError, "ActiveHashcash.throttle_rules rate must be >= 0" if rule[:rate].to_f.negative?
+    end
     @@throttle_rules = rules && rules.sort_by { |rule| rule[:period] }
   end
 

--- a/lib/active_hashcash.rb
+++ b/lib/active_hashcash.rb
@@ -109,14 +109,14 @@ module ActiveHashcash
   end
 
   # Returns the complexity, the higher the slower it is.
-  # Evantully adds a penality for pushy IPs, see hashcash_throttle_penality.
+  # Eventually adds a penalty for pushy IPs, see hashcash_throttle_penalty.
   def hashcash_bits
-    (ActiveHashcash.bits + hashcash_throttle_penality).floor
+    (ActiveHashcash.bits + hashcash_throttle_penalty).floor
   end
 
-  # Compute a penality for pushy IPs.
-  # The penality rules can be define with `ActiveHashcash.throttle_rules`.
-  def hashcash_throttle_penality
+  # Compute a penalty for pushy IPs.
+  # The penalty rules can be defined with `ActiveHashcash.throttle_rules`.
+  def hashcash_throttle_penalty
     rules = ActiveHashcash.throttle_rules || []
     periods = rules.map { |rule| rule[:period] }
     counts = ActiveHashcash::Stamp.where(ip_address: hashcash_ip_address).sum_by_periods(periods)

--- a/test/active_hashcash_test.rb
+++ b/test/active_hashcash_test.rb
@@ -10,31 +10,33 @@ class ActiveHashcashTest < ActiveSupport::TestCase
   end
 
   def test_hashcash_bits
+    bits = ActiveHashcash.bits
     controller = SampleController.new
     assert_equal(ActiveHashcash.bits, controller.hashcash_bits)
 
     ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:001").update!(ip_address: "127.0.0.1")
-    assert_equal(ActiveHashcash.bits, controller.hashcash_bits)
+    assert_equal((bits + 1 * 0.5).floor, controller.hashcash_bits)
 
     ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:002").update!(ip_address: "127.0.0.1")
-    assert_equal(ActiveHashcash.bits + 1, controller.hashcash_bits)
+    assert_equal((bits + 2 * 0.5).floor, controller.hashcash_bits)
 
     ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:003").update!(ip_address: "127.0.0.1")
-    assert_equal(ActiveHashcash.bits + 1, controller.hashcash_bits)
+    assert_equal((bits + 3 * 0.5).floor, controller.hashcash_bits)
 
     ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:004").update!(ip_address: "127.0.0.1")
-    assert_equal(ActiveHashcash.bits + 2, controller.hashcash_bits)
+    assert_equal((bits + 4 * 0.5).floor, controller.hashcash_bits)
 
-    ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:005").update!(ip_address: "127.0.0.1")
-    assert_equal(ActiveHashcash.bits + 2, controller.hashcash_bits)
+    ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:005").update!(ip_address: "127.0.0.1", created_at: 2.hours.ago)
+    assert_equal((bits + 4 * 0.5 + 1 * 0.25).floor, controller.hashcash_bits)
 
-    ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:006").update!(ip_address: "127.0.0.1")
-    assert_equal(ActiveHashcash.bits + 2, controller.hashcash_bits)
+    ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:006").update!(ip_address: "127.0.0.1", created_at: 2.hours.ago)
+    assert_equal((bits + 4 * 0.5 + 2 * 0.25).floor, controller.hashcash_bits)
 
-    ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:007").update!(ip_address: "127.0.0.1")
-    assert_equal(ActiveHashcash.bits + 2, controller.hashcash_bits)
+    ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:007").update!(ip_address: "127.0.0.1", created_at: 2.hours.ago)
+    assert_equal((bits + 4 * 0.5 + 3 * 0.25).floor, controller.hashcash_bits)
 
-    ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:008").update!(ip_address: "127.0.0.1")
-    assert_equal(ActiveHashcash.bits + 3, controller.hashcash_bits)
+    ActiveHashcash::Stamp.parse("1:20:220623:test:sha256:MPWRGuN3itbd1NiQ:008").update!(ip_address: "127.0.0.1", created_at: 2.hours.ago)
+    assert_equal((bits + 4 * 0.5 + 4 * 0.25).floor, controller.hashcash_bits)
   end
+
 end

--- a/test/active_hashcash_test.rb
+++ b/test/active_hashcash_test.rb
@@ -53,4 +53,15 @@ class ActiveHashcashTest < ActiveSupport::TestCase
     ActiveHashcash.throttle_rules = old_rules
   end
 
+  def test_throttle_rules_reject_negative_rate
+    old_rules = ActiveHashcash.throttle_rules
+
+    assert_raises(ArgumentError) do
+      ActiveHashcash.throttle_rules = [{period: 1.hour, rate: -0.5}]
+    end
+    assert_equal(old_rules, ActiveHashcash.throttle_rules)
+  ensure
+    ActiveHashcash.throttle_rules = old_rules
+  end
+
 end

--- a/test/active_hashcash_test.rb
+++ b/test/active_hashcash_test.rb
@@ -64,4 +64,15 @@ class ActiveHashcashTest < ActiveSupport::TestCase
     ActiveHashcash.throttle_rules = old_rules
   end
 
+  def test_throttle_rules_reject_nil_period
+    old_rules = ActiveHashcash.throttle_rules
+
+    assert_raises(ArgumentError) do
+      ActiveHashcash.throttle_rules = [{period: nil, rate: 0.5}]
+    end
+    assert_equal(old_rules, ActiveHashcash.throttle_rules)
+  ensure
+    ActiveHashcash.throttle_rules = old_rules
+  end
+
 end

--- a/test/active_hashcash_test.rb
+++ b/test/active_hashcash_test.rb
@@ -39,4 +39,18 @@ class ActiveHashcashTest < ActiveSupport::TestCase
     assert_equal((bits + 4 * 0.5 + 4 * 0.25).floor, controller.hashcash_bits)
   end
 
+  def test_throttle_rules_are_sorted
+    old_rules = ActiveHashcash.throttle_rules
+    ActiveHashcash.throttle_rules = [
+      {period: 24.hours, rate: 0.25},
+      {period: 5.minutes, rate: 1.0},
+      {period: 1.hour, rate: 0.5}
+    ]
+
+    assert_equal([5.minutes, 1.hour, 24.hours], ActiveHashcash.throttle_rules.map { |rule| rule[:period] })
+    assert_equal([1.0, 0.5, 0.25], ActiveHashcash.throttle_rules.map { |rule| rule[:rate] })
+  ensure
+    ActiveHashcash.throttle_rules = old_rules
+  end
+
 end


### PR DESCRIPTION
It allows to set fine rules with different rate and time periods:

```ruby
ActiveHashcash.throttle_rules = [
  {period: 1.hour, rate: 0.5},
  {period: 24.hours, rate: 0.25}
]
```

Thus in the last hour complexity increases by 0.5 for every successful stamp and by 0.25 between 1 and 24 hours ago.