### PR TITLE
Penalize Tor exit IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Penalize Tor exit IPs by 4 bits
 - Add `ActiveHashcash.throttle_rules` to slow down pushy IPs
 
 ## 0.5.0 (2026-08-08)

--- a/app/jobs/active_hashcash/update_tor_exit_ips_job.rb
+++ b/app/jobs/active_hashcash/update_tor_exit_ips_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+
+module ActiveHashcash
+  class UpdateTorExitIpsJob < ApplicationJob
+    URL = "https://check.torproject.org/torbulkexitlist"
+    CACHE_KEY = "ActiveHashcash::tor_exit_ips"
+    ENQUEUED_KEY = "ActiveHashcash::tor_exit_ips_enqueued"
+
+    def self.perform_later_once
+      perform_later if Rails.cache.write(ENQUEUED_KEY, true, unless_exist: true)
+    end
+
+    def perform
+      body = Net::HTTP.get(URI(URL))
+      ips = body.each_line.map(&:strip).reject(&:empty?).sort
+      Rails.cache.write(CACHE_KEY, {updated_at: Time.current, ips: ips})
+      self.class.set(wait: 1.hour).perform_later
+    ensure
+      Rails.cache.delete(ENQUEUED_KEY)
+    end
+  end
+end

--- a/app/jobs/active_hashcash/update_tor_exit_ips_job.rb
+++ b/app/jobs/active_hashcash/update_tor_exit_ips_job.rb
@@ -17,7 +17,6 @@ module ActiveHashcash
       body = Net::HTTP.get(URI(URL))
       ips = body.each_line.map(&:strip).reject(&:empty?).sort
       Rails.cache.write(CACHE_KEY, {updated_at: Time.current, ips: ips})
-      self.class.set(wait: 1.hour).perform_later
     ensure
       Rails.cache.delete(ENQUEUED_KEY)
     end

--- a/lib/active_hashcash.rb
+++ b/lib/active_hashcash.rb
@@ -30,6 +30,14 @@ module ActiveHashcash
   # Consider lowering it to not exclude people with old and slow devices.
   mattr_accessor :bits, instance_accessor: false, default: 20
 
+  # Returns the sorted Tor exit IP list from Rails.cache.
+  # Enqueues ActiveHashcash::UpdateTorExitIpsJob when the list is missing or older than one hour.
+  def self.tor_exit_ips
+    cached = Rails.cache.read(UpdateTorExitIpsJob::CACHE_KEY)
+    UpdateTorExitIpsJob.perform_later_once if !cached || !cached[:updated_at] || cached[:updated_at] < 1.hour.ago
+    cached&.fetch(:ips, []) || []
+  end
+
   # Flexible complexity penalty rules applied to pushy IP addresses.
   # Each rule must be a hash with:
   # - :period => time window considered (e.g. 5.minutes, 1.hour, 1.day)
@@ -110,9 +118,9 @@ module ActiveHashcash
   end
 
   # Returns the complexity, the higher the slower it is.
-  # Eventually adds a penalty for pushy IPs, see hashcash_throttle_penalty.
+  # Eventually adds penalties for pushy IPs and Tor exits
   def hashcash_bits
-    (ActiveHashcash.bits + hashcash_throttle_penalty).floor
+    (ActiveHashcash.bits + hashcash_throttle_penalty + hashcash_reputation_penalty).floor
   end
 
   # Compute a penalty for pushy IPs.
@@ -122,6 +130,17 @@ module ActiveHashcash
     periods = rules.map { |rule| rule[:period] }
     counts = ActiveHashcash::Stamp.where(ip_address: hashcash_ip_address).sum_by_periods(periods)
     rules.each_with_index.sum { |rule, index| counts[index].to_i * rule[:rate].to_f }
+  end
+
+  # Compute a reputation penalty for the current IP.
+  # Returns #hashcash_tor_penalty when the IP is a known Tor exit node.
+  def hashcash_reputation_penalty
+    ActiveHashcash.tor_exit_ips.bsearch { |ip| hashcash_ip_address <=> ip } ? hashcash_tor_penalty : 0
+  end
+
+  # Bits added when the request comes from a Tor exit node.
+  def hashcash_tor_penalty
+    4
   end
 
   # Override if you want to rename the hashcash param.

--- a/test/active_hashcash_test.rb
+++ b/test/active_hashcash_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class ActiveHashcashTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   class SampleController < ApplicationController
     include ActiveHashcash
 
@@ -73,6 +75,36 @@ class ActiveHashcashTest < ActiveSupport::TestCase
     assert_equal(old_rules, ActiveHashcash.throttle_rules)
   ensure
     ActiveHashcash.throttle_rules = old_rules
+  end
+
+  def test_tor_exit_ips_when_empty
+    with_memory_cache do
+      assert_enqueued_jobs(1, only: ActiveHashcash::UpdateTorExitIpsJob) do
+        2.times { assert_equal([], ActiveHashcash.tor_exit_ips) }
+      end
+    end
+  end
+
+  def test_tor_exit_ips_when_cached
+    with_memory_cache do
+      ips = ["1.2.3.4", "5.6.7.8"]
+      Rails.cache.write(ActiveHashcash::UpdateTorExitIpsJob::CACHE_KEY, {updated_at: Time.current, ips: ips})
+
+      assert_no_enqueued_jobs(only: ActiveHashcash::UpdateTorExitIpsJob) do
+        assert_equal(ips, ActiveHashcash.tor_exit_ips)
+      end
+    end
+  end
+
+  def test_tor_exit_ips_when_stale
+    with_memory_cache do
+      ips = ["1.2.3.4", "5.6.7.8"]
+      Rails.cache.write(ActiveHashcash::UpdateTorExitIpsJob::CACHE_KEY, {updated_at: 2.hours.ago, ips: ips})
+
+      assert_enqueued_with(job: ActiveHashcash::UpdateTorExitIpsJob) do
+        assert_equal(ips, ActiveHashcash.tor_exit_ips)
+      end
+    end
   end
 
 end

--- a/test/jobs/active_hashcash/update_tor_exit_ips_job_test.rb
+++ b/test/jobs/active_hashcash/update_tor_exit_ips_job_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class ActiveHashcash::UpdateTorExitIpsJobTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  def test_perform
+    with_memory_cache do
+      Rails.cache.write(ActiveHashcash::UpdateTorExitIpsJob::ENQUEUED_KEY, true)
+      ActiveHashcash::UpdateTorExitIpsJob.perform_now
+      cached = Rails.cache.read(ActiveHashcash::UpdateTorExitIpsJob::CACHE_KEY)
+      assert_not_nil(cached)
+      assert_kind_of(Time, cached[:updated_at])
+      assert_operator(cached[:ips].size, :>, 0)
+      assert_equal(cached[:ips].sort, cached[:ips])
+      assert(IPAddr.new(cached[:ips].first))
+      assert_nil(Rails.cache.read(ActiveHashcash::UpdateTorExitIpsJob::ENQUEUED_KEY))
+    end
+  end
+
+  def test_perform_later_once
+    with_memory_cache do
+      assert_enqueued_jobs(1, only: ActiveHashcash::UpdateTorExitIpsJob) do
+        2.times { ActiveHashcash::UpdateTorExitIpsJob.perform_later_once }
+      end
+      assert(Rails.cache.read(ActiveHashcash::UpdateTorExitIpsJob::ENQUEUED_KEY))
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,3 +13,13 @@ if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
   ActiveSupport::TestCase.file_fixture_path = File.expand_path("fixtures", __dir__) + "/files"
   ActiveSupport::TestCase.fixtures :all
 end
+
+class ActiveSupport::TestCase
+  def with_memory_cache
+    previous_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = previous_cache
+  end
+end


### PR DESCRIPTION
In my experience, signup attempts from Tor are spam bots. It's time they pay the price by adding a penalty of 4.